### PR TITLE
Multiple basket support

### DIFF
--- a/app/ro/riquack/shoppingbasket/actors/ActorFactory.scala
+++ b/app/ro/riquack/shoppingbasket/actors/ActorFactory.scala
@@ -7,7 +7,7 @@ import akka.actor.{ActorRef, ActorSystem, Props}
 import akka.util.Timeout
 
 import scala.concurrent.duration._
-import ro.riquack.shoppingbasket.repositories.StoreRepository
+import ro.riquack.shoppingbasket.repositories.{BasketRepository, StoreRepository}
 
 class ActorFactory @Inject()(actorSystem: ActorSystem) {
 
@@ -15,7 +15,7 @@ class ActorFactory @Inject()(actorSystem: ActorSystem) {
     actorSystem.actorOf(Props(classOf[StoreActor], new StoreRepository), s"store")
 
   val basketActor: ActorRef =
-    actorSystem.actorOf(Props(classOf[BasketActor]), s"basket-${UUID.randomUUID()}")
+    actorSystem.actorOf(Props(classOf[BasketActor], new BasketRepository),s"basket-${UUID.randomUUID()}")
 
 }
 

--- a/app/ro/riquack/shoppingbasket/actors/BasketActor.scala
+++ b/app/ro/riquack/shoppingbasket/actors/BasketActor.scala
@@ -2,34 +2,63 @@ package ro.riquack.shoppingbasket.actors
 
 import akka.actor.{Actor, ActorLogging}
 import ro.riquack.shoppingbasket.actors.messages.BasketMessage._
-import ro.riquack.shoppingbasket.models.{Basket, BasketItem}
+import ro.riquack.shoppingbasket.repositories.BasketRepository
 
 
-class BasketActor() extends Actor with ActorLogging {
-
-  private val basket = Basket(List.empty[BasketItem])
+class BasketActor(basketRepository: BasketRepository) extends Actor with ActorLogging {
 
   override def preStart(): Unit = log.info("Starting...")
 
   override def receive: Receive = {
 
-    case ListProducts =>
-      sender() ! RevealedContent(basket)
-      log.info("Retrieved items in the basket...")
-
-    case AddProduct(item, amount) =>
-      basket.add(item, amount)
-      log.info(s"Added $amount x ${item.id} to basket...")
-
-    case RemoveProduct(id) =>
-      basket.retrieve(id) match {
-        case Some(basketItem) =>
-          basket.remove(basketItem)
-          sender() ! Revealed(basketItem)
-          log.info(s"Removed $id from basket...")
+    case ListProducts(basketId) =>
+      basketRepository.retrieve(basketId) match {
+        case Some(basket) =>
+          sender() ! RevealedContent(basket)
+          log.info("Retrieved items in the basket")
         case None =>
-          sender() ! ItemNotFound
-          log.info(s"Missing $id from basket...")
+          sender() ! BasketNotFound
+          log.info("No such basket")
+      }
+
+    case AddProduct(basketId, item, amount) =>
+      basketRepository.retrieve(basketId) match {
+        case Some(_) =>
+          basketRepository.addTo(basketId, item, amount)
+          log.info(s"Added $amount x ${item.id} to basket")
+        case None =>
+          sender() ! BasketNotFound
+          log.info("No such basket")
+      }
+
+    case RemoveProduct(basketId, itemId) =>
+      basketRepository.retrieve(basketId) match {
+        case Some(basket) =>
+          basket.retrieve(itemId) match {
+            case Some(basketItem) =>
+              basketRepository.removeFrom(basketId, basketItem)
+              sender() ! Revealed(basketItem)
+            case None =>
+              sender() ! ItemNotFound
+              log.info(s"Missing $itemId from basket")
+          }
+        case None =>
+          sender() ! BasketNotFound
+          log.info("No such basket")
+      }
+
+    case CreateBasket =>
+      val basketId = basketRepository.create()
+      sender() ! CreatedBasket(basketId)
+      log.info(s"Created basket $basketId")
+
+    case RemoveBasket(basketId: String) =>
+      basketRepository.remove(basketId) match {
+        case Some(_) =>
+          log.info(s"Removed basket $basketId")
+        case None =>
+          sender() ! BasketNotFound
+          log.info("No such basket")
       }
   }
 

--- a/app/ro/riquack/shoppingbasket/actors/BasketActor.scala
+++ b/app/ro/riquack/shoppingbasket/actors/BasketActor.scala
@@ -25,6 +25,7 @@ class BasketActor(basketRepository: BasketRepository) extends Actor with ActorLo
       basketRepository.retrieve(basketId) match {
         case Some(_) =>
           basketRepository.addTo(basketId, item, amount)
+          sender() ! ItemAdded
           log.info(s"Added $amount x ${item.id} to basket")
         case None =>
           sender() ! BasketNotFound
@@ -52,14 +53,6 @@ class BasketActor(basketRepository: BasketRepository) extends Actor with ActorLo
       sender() ! CreatedBasket(basketId)
       log.info(s"Created basket $basketId")
 
-    case RemoveBasket(basketId: String) =>
-      basketRepository.remove(basketId) match {
-        case Some(_) =>
-          log.info(s"Removed basket $basketId")
-        case None =>
-          sender() ! BasketNotFound
-          log.info("No such basket")
-      }
   }
 
 }

--- a/app/ro/riquack/shoppingbasket/actors/messages/BasketMessage.scala
+++ b/app/ro/riquack/shoppingbasket/actors/messages/BasketMessage.scala
@@ -15,12 +15,15 @@ trait BasketOutboundMessage
 
 object BasketMessage {
 
-  case object ListProducts extends BasketInboundMessage
+  case class ListProducts(basketId: String) extends BasketInboundMessage
 
-  case class AddProduct(item: Item, amount: Int) extends BasketInboundMessage
+  case class AddProduct(basketId: String, item: Item, amount: Int) extends BasketInboundMessage
 
-  case class RemoveProduct(id: String) extends BasketInboundMessage
+  case class RemoveProduct(basketId: String, id: String) extends BasketInboundMessage
 
+  case object CreateBasket extends BasketInboundMessage
+
+  case class RemoveBasket(basketId: String) extends BasketInboundMessage
 
 
   case class Revealed(basketItem: BasketItem) extends BasketOutboundMessage
@@ -30,6 +33,12 @@ object BasketMessage {
   case object ItemAdded extends BasketOutboundMessage
 
   case object ItemNotFound extends BasketOutboundMessage
+
+  case object BasketNotFound extends BasketOutboundMessage
+
+  case class CreatedBasket(id: String)  extends BasketOutboundMessage
+
+  case object RemovedBasket extends BasketOutboundMessage
 }
 
 

--- a/app/ro/riquack/shoppingbasket/api/controllers/BasketController.scala
+++ b/app/ro/riquack/shoppingbasket/api/controllers/BasketController.scala
@@ -25,6 +25,7 @@ class BasketController @Inject() (basketService: BasketService)(implicit ec: Exe
     basketService.list(basketId).map {
       case Right(RetrieveSuccess(basket)) => Ok(Json.toJson(basket))
       case Left(UnexpectedMessageError) => ControllerMessages.internalServerError
+      case Left(MissingBasketError) => ControllerMessages.basketNotFound
     }
 
   }
@@ -36,7 +37,8 @@ class BasketController @Inject() (basketService: BasketService)(implicit ec: Exe
       item =>
         basketService.add(basketId, item).map {
           case Right(Success) => Created.withHeaders(LOCATION -> routes.BasketController.list(basketId).url)
-          case Left(MissingItemError) => ControllerMessages.notFound
+          case Left(MissingItemError) => ControllerMessages.itemNotFound
+          case Left(MissingBasketError) => ControllerMessages.basketNotFound
           case Left(InsufficientStockError) => ControllerMessages.insufficientStock
           case Left(UnexpectedMessageError) => ControllerMessages.internalServerError
         }
@@ -46,7 +48,8 @@ class BasketController @Inject() (basketService: BasketService)(implicit ec: Exe
   def remove(basketId: String, itemId: String) = Action.async { implicit request =>
     basketService.remove(basketId, itemId).map {
       case Right(Success) => Ok
-      case Left(MissingItemError) => ControllerMessages.notFound
+      case Left(MissingItemError) => ControllerMessages.itemNotFound
+      case Left(MissingBasketError) => ControllerMessages.basketNotFound
       case Left(UnexpectedMessageError) => ControllerMessages.internalServerError
 
     }

--- a/app/ro/riquack/shoppingbasket/api/controllers/ControllerMessages.scala
+++ b/app/ro/riquack/shoppingbasket/api/controllers/ControllerMessages.scala
@@ -7,7 +7,8 @@ import play.api.mvc.Results._
 object ControllerMessages {
 
   val insufficientStock = BadRequest(Json.toJson(ErrorDTO("Not enough stock for the request item.")))
-  val notFound = NotFound(Json.toJson(ErrorDTO("Requested item was not found.")))
+  val itemNotFound = NotFound(Json.toJson(ErrorDTO("Requested item was not found.")))
+  val basketNotFound = NotFound(Json.toJson(ErrorDTO("Requested basket was not found.")))
   val internalServerError = InternalServerError(Json.toJson(ErrorDTO("An unexpected error occurred.")))
   val wrongPayload = BadRequest(Json.toJson(ErrorDTO("Supplied payload does not have the required elements.")))
 

--- a/app/ro/riquack/shoppingbasket/api/controllers/StoreController.scala
+++ b/app/ro/riquack/shoppingbasket/api/controllers/StoreController.scala
@@ -27,7 +27,7 @@ class StoreController @Inject () (storeService: StoreService)(implicit ec: Execu
 
     storeService.retrieve(id).map {
       case Right(FindSuccess(item)) => Ok(Json.toJson(item))
-      case Left(MissingItemError) => ControllerMessages.notFound
+      case Left(MissingItemError) => ControllerMessages.itemNotFound
       case Left(UnexpectedMessageError) => ControllerMessages.internalServerError
     }
   }

--- a/app/ro/riquack/shoppingbasket/repositories/BasketRepository.scala
+++ b/app/ro/riquack/shoppingbasket/repositories/BasketRepository.scala
@@ -19,14 +19,10 @@ class BasketRepository {
 
   def retrieve(id: String): Option[Basket] = storage.get(id)
 
-  def remove(id: String): Option[Basket] = storage.remove(id)
-
   def addTo(basketId: String, item: Item, amount: Int): Unit =
     storage(basketId).add(item, amount)
 
   def removeFrom(basketId: String, basketItem: BasketItem): Unit =
     storage(basketId).remove(basketItem)
-
-
 
 }

--- a/app/ro/riquack/shoppingbasket/repositories/BasketRepository.scala
+++ b/app/ro/riquack/shoppingbasket/repositories/BasketRepository.scala
@@ -1,0 +1,32 @@
+package ro.riquack.shoppingbasket.repositories
+
+import java.util.UUID
+
+import ro.riquack.shoppingbasket.models.{Basket, BasketItem, Item}
+
+import scala.collection.mutable
+
+
+class BasketRepository {
+
+  private val storage = mutable.HashMap.empty[String, Basket]
+
+  def create(): String = {
+    val uuid = UUID.randomUUID().toString
+    storage.put(uuid, new Basket(List.empty[BasketItem]))
+    uuid
+  }
+
+  def retrieve(id: String): Option[Basket] = storage.get(id)
+
+  def remove(id: String): Option[Basket] = storage.remove(id)
+
+  def addTo(basketId: String, item: Item, amount: Int): Unit =
+    storage(basketId).add(item, amount)
+
+  def removeFrom(basketId: String, basketItem: BasketItem): Unit =
+    storage(basketId).remove(basketItem)
+
+
+
+}

--- a/app/ro/riquack/shoppingbasket/services/BasketService.scala
+++ b/app/ro/riquack/shoppingbasket/services/BasketService.scala
@@ -11,7 +11,7 @@ import ro.riquack.shoppingbasket.api.dto.ItemDTO
 import ro.riquack.shoppingbasket.actors.messages.BasketMessage._
 import ro.riquack.shoppingbasket.actors.messages.StoreMessage
 import ro.riquack.shoppingbasket.actors.messages.StoreMessage.{DecrementStock, IncrementStock}
-import ro.riquack.shoppingbasket.services.responses.BasketServiceError.{InsufficientStockError, MissingItemError, UnexpectedMessageError}
+import ro.riquack.shoppingbasket.services.responses.BasketServiceError.{InsufficientStockError, MissingItemError, UnexpectedMessageError, MissingBasketError}
 import ro.riquack.shoppingbasket.services.responses.BasketServiceResponse.{CreateSuccess, RetrieveSuccess, Success}
 import ro.riquack.shoppingbasket.services.responses.{BasketServiceError, BasketServiceResponse}
 
@@ -28,22 +28,27 @@ class BasketService @Inject() (
   def list(basketId: String): Future[Either[BasketServiceError, BasketServiceResponse]] =
     (basketActor ? ListProducts(basketId)).map {
       case RevealedContent(basket) => Right(RetrieveSuccess(basket))
+      case BasketNotFound => Left(MissingBasketError)
       case _ => Left(UnexpectedMessageError)
     }
 
   def add(basketId: String, item: ItemDTO): Future[Either[BasketServiceError, BasketServiceResponse]] = {
-    (storeActor ? DecrementStock(item)).map {
+    (storeActor ? DecrementStock(item)).flatMap {
         case StoreMessage.Revealed(storeItem) =>
-          basketActor ! AddProduct(basketId, storeItem.item, item.amount)
-            Right(Success)
-        case StoreMessage.ItemNotFound => Left(MissingItemError)
-        case StoreMessage.ItemInsufficientStock =>  Left(InsufficientStockError)
-        case _ => Left(UnexpectedMessageError)
+          (basketActor ? AddProduct(basketId, storeItem.item, item.amount)).map {
+            case ItemAdded => Right(Success)
+            case BasketNotFound => Left(MissingBasketError)
+          }
+
+        case StoreMessage.ItemNotFound => Future.successful(Left(MissingItemError))
+        case StoreMessage.ItemInsufficientStock =>  Future.successful(Left(InsufficientStockError))
+        case _ => Future.successful(Left(UnexpectedMessageError))
       }
   }
 
   def remove(basketId: String, itemId: String): Future[Either[BasketServiceError, BasketServiceResponse]] = {
     (basketActor ? RemoveProduct(basketId, itemId)).map {
+      case BasketNotFound => Left(MissingBasketError)
       case Revealed(basketItem) => {
         storeActor ! IncrementStock(basketItem)
         Right(Success)

--- a/app/ro/riquack/shoppingbasket/services/responses/BasketServiceError.scala
+++ b/app/ro/riquack/shoppingbasket/services/responses/BasketServiceError.scala
@@ -6,6 +6,7 @@ object BasketServiceError {
   case object UnexpectedMessageError extends BasketServiceError
   case object InsufficientStockError extends BasketServiceError
   case object MissingItemError extends BasketServiceError
+  case object MissingBasketError extends BasketServiceError
 }
 
 

--- a/app/ro/riquack/shoppingbasket/services/responses/BasketServiceResponse.scala
+++ b/app/ro/riquack/shoppingbasket/services/responses/BasketServiceResponse.scala
@@ -7,6 +7,7 @@ trait BasketServiceResponse
 object BasketServiceResponse {
   case object Success extends BasketServiceResponse
   case class RetrieveSuccess(basket: Basket) extends BasketServiceResponse
+  case class CreateSuccess(basketId: String) extends BasketServiceResponse
 }
 
 

--- a/conf/routes
+++ b/conf/routes
@@ -1,8 +1,10 @@
 # Shopping Basket API endpoints
 
 GET         /items                                      ro.riquack.shoppingbasket.api.controllers.StoreController.list
-GET         /items/:id                                  ro.riquack.shoppingbasket.api.controllers.StoreController.retrieve(id: String)
+GET         /items/:item                                ro.riquack.shoppingbasket.api.controllers.StoreController.retrieve(item: String)
 
-GET         /basket/items                               ro.riquack.shoppingbasket.api.controllers.BasketController.list
-POST        /basket/items                               ro.riquack.shoppingbasket.api.controllers.BasketController.add
-DELETE      /basket/items/:id                           ro.riquack.shoppingbasket.api.controllers.BasketController.remove(id: String)
+GET         /basket/:basket                             ro.riquack.shoppingbasket.api.controllers.BasketController.list(basket: String)
+POST        /basket/:basket                             ro.riquack.shoppingbasket.api.controllers.BasketController.add(basket: String)
+DELETE      /basket/:basket/items/:item                 ro.riquack.shoppingbasket.api.controllers.BasketController.remove(basket: String, item: String)
+
+POST        /basket                                     ro.riquack.shoppingbasket.api.controllers.BasketController.create

--- a/test/ro/riquack/shoppingbasket/TestValues.scala
+++ b/test/ro/riquack/shoppingbasket/TestValues.scala
@@ -26,5 +26,6 @@ trait TestValues {
   def defaultStoreItems = List(storePhone, storeNotebook, storeBike)
 
   def defaultBasket = Basket(List(basketPhone))
+  def emptyBasket = Basket(List.empty[BasketItem])
 
 }

--- a/test/ro/riquack/shoppingbasket/actors/BasketActorSpec.scala
+++ b/test/ro/riquack/shoppingbasket/actors/BasketActorSpec.scala
@@ -1,55 +1,82 @@
 package ro.riquack.shoppingbasket.actors
 
-import akka.actor.ActorSystem
 import akka.pattern.ask
-import akka.testkit.{TestActorRef, TestKit}
+import akka.testkit.TestActorRef
 import akka.util.Timeout
+import org.mockito.Mockito.when
+import org.mockito.Matchers.any
 import org.scalatest.concurrent.ScalaFutures
+import org.scalatest.mockito.MockitoSugar
 import org.scalatest.{MustMatchers, WordSpecLike}
-import ro.riquack.shoppingbasket.TestValues
+import ro.riquack.shoppingbasket.{TestKitSugar, TestValues}
 import ro.riquack.shoppingbasket.actors.messages.BasketMessage._
 import ro.riquack.shoppingbasket.models.Basket
+import ro.riquack.shoppingbasket.repositories.BasketRepository
 
 import scala.concurrent.duration._
 
-class BasketActorSpec extends TestKit(ActorSystem("test-store"))
+class BasketActorSpec extends TestKitSugar
   with WordSpecLike
   with MustMatchers
   with ScalaFutures
-  with TestValues {
+  with TestValues
+  with MockitoSugar {
 
   implicit val askTimeout = Timeout(2.seconds)
+  private val mockBasketRepository = mock[BasketRepository]
+  private val basketId = "1s-ve"
 
   "A BasketActor" must {
 
-    "send back the items in the basket" in {
-      val basketActorRef = TestActorRef[BasketActor]
-      val result =  (basketActorRef ? ListProducts).futureValue
+    "create a basket in the system" in {
+     when(mockBasketRepository.create()) thenReturn basketId
+     val basketActorRef = TestActorRef(new BasketActor(mockBasketRepository))
+     val result =  (basketActorRef ? CreateBasket).futureValue
 
-      result mustEqual RevealedContent(Basket(List.empty))
+     result mustEqual CreatedBasket("1s-ve")
+    }
+
+    "send back the items in the basket" in {
+      when(mockBasketRepository.retrieve(any[String])) thenReturn Some(defaultBasket)
+      val basketActorRef = TestActorRef(new BasketActor(mockBasketRepository))
+      val result =  (basketActorRef ? ListProducts(basketId)).futureValue
+
+      result mustEqual RevealedContent(Basket(List(basketPhone)))
     }
 
     "add an item to the basket" in {
-      val basketActorRef = TestActorRef[BasketActor]
+      when(mockBasketRepository.retrieve(any[String])) thenReturn Some(defaultBasket)
+      val basketActorRef = TestActorRef(new BasketActor(mockBasketRepository))
       within(100 millis) {
-        basketActorRef ! AddProduct(phone, 1)
+        basketActorRef ! AddProduct(basketId, phone, 1)
         expectNoMsg()
       }
     }
 
     "remove an item from the basket" in {
-      val basketActorRef = TestActorRef[BasketActor]
-      basketActorRef ! AddProduct(phone, 2)
-      val result = (basketActorRef ? RemoveProduct("ae4cd")).futureValue
+      when(mockBasketRepository.retrieve(any[String])) thenReturn Some(defaultBasket)
+      val basketActorRef = TestActorRef(new BasketActor(mockBasketRepository))
+      basketActorRef ! AddProduct(basketId, phone, 2)
+      val result = (basketActorRef ? RemoveProduct(basketId, "ae4cd")).futureValue
 
       result mustEqual Revealed(basketPhone)
     }
 
     "inform that an item is not in the basket thus can't be removed" in {
-      val basketActorRef = TestActorRef[BasketActor]
-      val result = (basketActorRef ? RemoveProduct("ae4cd")).futureValue
+      when(mockBasketRepository.retrieve(any[String])) thenReturn Some(emptyBasket)
+      val basketActorRef = TestActorRef(new BasketActor(mockBasketRepository))
+      val result = (basketActorRef ? RemoveProduct(basketId, "ae4cd")).futureValue
 
       result mustEqual ItemNotFound
     }
+
+    "inform that a basket does not exist in the system" in {
+      when(mockBasketRepository.retrieve(any[String])) thenReturn None
+      val basketActorRef = TestActorRef(new BasketActor(mockBasketRepository))
+      val result = (basketActorRef ? ListProducts(basketId)).futureValue
+
+      result mustEqual BasketNotFound
+    }
+
   }
 }

--- a/test/ro/riquack/shoppingbasket/controllers/BasketControllerSpec.scala
+++ b/test/ro/riquack/shoppingbasket/controllers/BasketControllerSpec.scala
@@ -26,61 +26,62 @@ class BasketControllerSpec extends PlaySpec with MockitoSugar with OneAppPerSuit
 
   private val mockBasketService = mock[BasketService]
   private val controller = new BasketController(mockBasketService)
+  private val basketId = "1s-ve"
 
   "A BasketController" should {
 
     "retrieve the list of items in the basket" in {
-      when(mockBasketService.list) thenReturn Future(Right(RetrieveSuccess(defaultBasket)))
+      when(mockBasketService.list(any[String])) thenReturn Future(Right(RetrieveSuccess(defaultBasket)))
 
-      val result = controller.list(FakeRequest(GET, "/basket/items"))
+      val result = controller.list(basketId)(FakeRequest(GET, "/basket/items"))
       assert(status(result) == OK)
     }
 
     "successfully add an existing item if the stock is sufficient" in {
-      when(mockBasketService.add(any[ItemDTO])) thenReturn Future(Right(Success))
+      when(mockBasketService.add(any[String], any[ItemDTO])) thenReturn Future(Right(Success))
 
       val req = FakeRequest(POST, "/basket/items")
         .withBody("""{"id":"as31fs","amount":3}""")
         .withHeaders(CONTENT_TYPE -> "application/json")
 
-      val result = call(controller.add,req)
+      val result = call(controller.add(basketId),req)
       assert(status(result) == CREATED)
     }
 
 
     "inform the user that there is not enough stock for an existing item" in {
-      when(mockBasketService.add(any[ItemDTO])) thenReturn Future(Left(InsufficientStockError))
+      when(mockBasketService.add(any[String], any[ItemDTO])) thenReturn Future(Left(InsufficientStockError))
 
       val req = FakeRequest(POST, "/basket/items")
         .withBody("""{"id":"as31fs","amount":3}""")
         .withHeaders(CONTENT_TYPE -> "application/json")
 
-      val result = call(controller.add,req)
+      val result = call(controller.add(basketId),req)
       assert(status(result) == BAD_REQUEST)
     }
 
     "inform the user that the item is not valid" in {
-      when(mockBasketService.add(any[ItemDTO])) thenReturn Future(Left(MissingItemError))
+      when(mockBasketService.add(any[String], any[ItemDTO])) thenReturn Future(Left(MissingItemError))
 
       val req = FakeRequest(POST, "/basket/items")
         .withBody("""{"id":"as31fs","amount":3}""")
         .withHeaders(CONTENT_TYPE -> "application/json")
 
-      val result = call(controller.add,req)
+      val result = call(controller.add(basketId),req)
       assert(status(result) == NOT_FOUND)
     }
 
     "remove an existing item from the basket" in {
-      when(mockBasketService.remove(any[String])) thenReturn Future(Right(Success))
+      when(mockBasketService.remove(any[String], any[String])) thenReturn Future(Right(Success))
 
-      val result = controller.remove("asd3as")(FakeRequest("DELETE", "/basket/items/asd3as"))
+      val result = controller.remove(basketId, "asd3as")(FakeRequest("DELETE", "/basket/items/asd3as"))
       assert(status(result) == OK)
     }
 
     "inform the user that there is no such item in the basket" in {
-      when(mockBasketService.remove(any[String])) thenReturn Future(Left(MissingItemError))
+      when(mockBasketService.remove(any[String], any[String])) thenReturn Future(Left(MissingItemError))
 
-      val result = controller.remove("asd3as")(FakeRequest("DELETE", "/basket/items/asd3as"))
+      val result = controller.remove(basketId, "asd3as")(FakeRequest("DELETE", "/basket/items/asd3as"))
       assert(status(result) == NOT_FOUND)
     }
 


### PR DESCRIPTION
Allow multiple baskets in the system.

First the API client will need to create a basket for his session. 
The following actions will be done using the basket ID provided in the location header of the response.